### PR TITLE
feat(harvester): speed up OCR with persistent daemon workers

### DIFF
--- a/scripts/scoreboard-harvester/README.md
+++ b/scripts/scoreboard-harvester/README.md
@@ -29,7 +29,7 @@ Output goes to `out/<game-id>/<video-id>/`. For YouTube the `<video-id>` is the 
 
 1. **Sample** the video at 1 fps (configurable) into `out/<game>/<video>/frames/*.jpg` via ffmpeg with VideoToolbox hwaccel.
 2. **pHash filter** (optional, when a reference exists for the active game): drop frames whose dHash differs from the reference by more than `--phash-threshold`. Massively speeds things up for clean game captures.
-3. **Vision OCR** each surviving frame with the compiled Swift binary. A frame is *confirmed* when its OCR text contains at least `--ocr-min-keywords` of the active game's keyword list.
+3. **Vision OCR** each surviving frame with the compiled Swift binary. A frame is _confirmed_ when its OCR text contains at least `--ocr-min-keywords` of the active game's keyword list.
 4. **Skip-ahead**: once a confirmed run ends, jump forward `--skip-ahead-sec` seconds before resuming OCR. Per-game default; tied to the shortest possible interval between two consecutive matches.
 5. **Dedup**: cluster confirmed frames whose frame-IDs are within `--dedup-gap` of each other into a single match, pick the sharpest frame from the middle of the run, save as `match-NN_t=<hh-mm-ss>.png`.
 6. **Manifest**: write `manifest.json` with the game, source, config, runtime, and per-match metadata.
@@ -68,6 +68,9 @@ bootstrap   Set the pHash reference image for the active --game.
 --out <dir>             Output root (default: ./out)
 --fps <n>               Sample rate (game-default if omitted)
 --quality <px>          Max download height (default: 720)
+--sample-width <px>     Extracted frame width (default: 1280; try 960)
+--jpeg-quality <n>      ffmpeg JPEG q value, lower is better (default: 3; try 5)
+--ocr-concurrency <n>   Persistent OCR workers (default: 2; benchmark 1, 2, 4)
 --start <sec>           Start time slice (debugging)
 --end <sec>             End time slice (debugging)
 --reference <path>      Override pHash reference image
@@ -92,12 +95,38 @@ Tuning live in the GameProfile (`defaults.minMatchIntervalSec`). Overridable per
 
 Real-world impact on RDC RL videos:
 
-| Video | Without skip | With skip-180 | Savings |
-|---|---|---|---|
-| 2 hr, 17 matches | 7,200 frames | ~4,140 frames | ~42% |
-| 1 hr 8 min, 10 matches | 4,103 frames | ~2,300 frames | ~44% |
+| Video                  | Without skip | With skip-180 | Savings |
+| ---------------------- | ------------ | ------------- | ------- |
+| 2 hr, 17 matches       | 7,200 frames | ~4,140 frames | ~42%    |
+| 1 hr 8 min, 10 matches | 4,103 frames | ~2,300 frames | ~44%    |
 
-Trade-off: a noisy mid-match HUD that briefly hits the keyword threshold *and* survives the `dedup-gap` window could cause the loop to skip past a real match. The defaults are tuned to make this very unlikely (≥ 4 unique keywords, run must end naturally), but `--no-skip-ahead` is the escape hatch.
+Trade-off: a noisy mid-match HUD that briefly hits the keyword threshold _and_ survives the `dedup-gap` window could cause the loop to skip past a real match. The defaults are tuned to make this very unlikely (≥ 4 unique keywords, run must end naturally), but `--no-skip-ahead` is the escape hatch.
+
+## Performance tuning
+
+OCR runs through persistent `vision-ocr --daemon` workers. This avoids paying Swift/Vision process startup for every frame, and `--ocr-concurrency` controls how many workers run at once. Results are still applied in frame order so skip-ahead and dedup behave like the old sequential loop.
+
+Frame extraction now exposes the pixel and JPEG quality knobs that usually matter most for throughput. The default stays conservative (`--sample-width 1280 --jpeg-quality 3`), but Rocket League videos are good candidates for benchmarking `--sample-width 960 --jpeg-quality 5`.
+
+Recommended slice benchmark:
+
+```bash
+npm run harvest:build-ocr
+
+npm run harvest -- extract --game rocket-league --video ./game.mp4 \
+  --out ./out/bench-c1 --start 600 --end 900 --keep-frames \
+  --no-phash --ocr-concurrency 1
+
+npm run harvest -- extract --game rocket-league --video ./game.mp4 \
+  --out ./out/bench-c2 --start 600 --end 900 --keep-frames \
+  --no-phash --ocr-concurrency 2
+
+npm run harvest -- extract --game rocket-league --video ./game.mp4 \
+  --out ./out/bench-c4-960 --start 600 --end 900 --keep-frames \
+  --no-phash --ocr-concurrency 4 --sample-width 960 --jpeg-quality 5
+```
+
+Compare runtime plus `confirmed` and saved match counts before changing defaults for a game profile or workflow.
 
 ## Resumability
 
@@ -114,7 +143,9 @@ Interrupt with ^C, restart with the same args, and it picks up where it left off
 {
   "game": "rocket-league",
   "source": { "url": "...", "filePath": "...", "durationSec": 4103, "fps": 1 },
-  "config": { /* resolved flags incl. gameId, skipAheadFrames, etc. */ },
+  "config": {
+    /* resolved flags incl. gameId, skipAheadFrames, etc. */
+  },
   "runtimeMs": 1837886,
   "matches": [
     {
@@ -143,18 +174,18 @@ When wired, the harvester will pass `GameProfile.azureGameId` automatically. For
 
 ## Troubleshooting
 
-| Symptom | Fix |
-|---|---|
-| `yt-dlp not found` | `brew install yt-dlp` |
-| `ffmpeg not found` | `brew install ffmpeg` |
-| `vision-ocr binary not built` | `npm run harvest:build-ocr` |
-| `[phash] 0 frames survived filter` | Stream overlays make pHash unreliable. Use `--no-phash` (see below). |
-| No matches detected | Lower `--ocr-min-keywords` (try 3) or `--quality 1080` |
-| Reference image missing | Run `bootstrap --game <id>` once, or drop your own at `reference/<id>/scoreboard.png` |
-| Too many false positives | Raise `--ocr-min-keywords` (try 5), add `--require-end-screen`, or lower `--phash-threshold` |
-| Duplicate detections close in time | Raise `--dedup-gap` (e.g. 20); per-game default is in the profile |
-| Skip-ahead missed a match | Use `--no-skip-ahead` or lower `--skip-ahead-sec` |
-| Vision OCR fails to load | Run from a normal terminal — sandboxed shells block `~/Library/Caches` access |
+| Symptom                            | Fix                                                                                          |
+| ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| `yt-dlp not found`                 | `brew install yt-dlp`                                                                        |
+| `ffmpeg not found`                 | `brew install ffmpeg`                                                                        |
+| `vision-ocr binary not built`      | `npm run harvest:build-ocr`                                                                  |
+| `[phash] 0 frames survived filter` | Stream overlays make pHash unreliable. Use `--no-phash` (see below).                         |
+| No matches detected                | Lower `--ocr-min-keywords` (try 3) or `--quality 1080`                                       |
+| Reference image missing            | Run `bootstrap --game <id>` once, or drop your own at `reference/<id>/scoreboard.png`        |
+| Too many false positives           | Raise `--ocr-min-keywords` (try 5), add `--require-end-screen`, or lower `--phash-threshold` |
+| Duplicate detections close in time | Raise `--dedup-gap` (e.g. 20); per-game default is in the profile                            |
+| Skip-ahead missed a match          | Use `--no-skip-ahead` or lower `--skip-ahead-sec`                                            |
+| Vision OCR fails to load           | Run from a normal terminal — sandboxed shells block `~/Library/Caches` access                |
 
 ### `--no-phash`: when to use it
 

--- a/scripts/scoreboard-harvester/index.ts
+++ b/scripts/scoreboard-harvester/index.ts
@@ -24,15 +24,14 @@ import { dedupAndSave } from "./pipeline/dedup";
 import { submitMatches } from "./pipeline/submit";
 import { parseFiniteNumber, sanitizeUrl, urlToSlug } from "./utils";
 import { FrameRecord, Manifest, ResolvedConfig } from "./types";
-import {
-  DEFAULT_GAME_ID,
-  listGameIds,
-  resolveProfile,
-} from "./games/registry";
+import { DEFAULT_GAME_ID, listGameIds, resolveProfile } from "./games/registry";
 import type { GameProfile } from "./games/types";
 
 const HARVESTER_ROOT = __dirname;
 const COMMANDS = ["extract", "bootstrap"] as const;
+const DEFAULT_SAMPLE_WIDTH = 1280;
+const DEFAULT_JPEG_QUALITY = 3;
+const DEFAULT_OCR_CONCURRENCY = 2;
 type Command = (typeof COMMANDS)[number];
 
 interface ParsedArgs {
@@ -68,6 +67,12 @@ function parseInputs(): ParsedArgs {
       "skip-ahead-sec": { type: "string" },
       "no-skip-ahead": { type: "boolean", default: false },
       quality: { type: "string", default: "720" },
+      "sample-width": { type: "string", default: String(DEFAULT_SAMPLE_WIDTH) },
+      "jpeg-quality": { type: "string", default: String(DEFAULT_JPEG_QUALITY) },
+      "ocr-concurrency": {
+        type: "string",
+        default: String(DEFAULT_OCR_CONCURRENCY),
+      },
       "keep-frames": { type: "boolean", default: false },
       start: { type: "string" },
       end: { type: "string" },
@@ -159,6 +164,27 @@ function parseInputs(): ParsedArgs {
     min: 144,
     max: 4320,
   })!;
+  const sampleWidth = parseFiniteNumber({
+    name: "sample-width",
+    raw: values["sample-width"],
+    kind: "int",
+    min: 320,
+    max: 4320,
+  })!;
+  const jpegQuality = parseFiniteNumber({
+    name: "jpeg-quality",
+    raw: values["jpeg-quality"],
+    kind: "int",
+    min: 1,
+    max: 31,
+  })!;
+  const ocrConcurrency = parseFiniteNumber({
+    name: "ocr-concurrency",
+    raw: values["ocr-concurrency"],
+    kind: "int",
+    min: 1,
+    max: 8,
+  })!;
   const start = parseFiniteNumber({
     name: "start",
     raw: values.start,
@@ -196,6 +222,9 @@ function parseInputs(): ParsedArgs {
     dedupGap,
     skipAheadFrames,
     quality,
+    sampleWidth,
+    jpegQuality,
+    ocrConcurrency,
     keepFrames: Boolean(values["keep-frames"]),
     start,
     end,
@@ -332,6 +361,9 @@ I/O:
   --out <dir>             Output root (default: ./out → out/<game>/<video>/)
   --fps <n>               Frames per second to sample (game-default if omitted)
   --quality <px>          Max download height (default: 720)
+  --sample-width <px>     Extracted frame width (default: ${DEFAULT_SAMPLE_WIDTH}; try 960)
+  --jpeg-quality <n>      ffmpeg JPEG q value, lower is better (default: ${DEFAULT_JPEG_QUALITY}; try 5)
+  --ocr-concurrency <n>   Persistent OCR workers (default: ${DEFAULT_OCR_CONCURRENCY})
   --start <sec>           Start time slice (debugging)
   --end <sec>             End time slice (debugging)
   --reference <path>      Override pHash reference image
@@ -399,7 +431,9 @@ async function acquireVideo(args: {
   const workDir = path.join(config.out, config.gameId, videoId);
   fs.mkdirSync(workDir, { recursive: true });
   durationSec = await probeDuration(ffprobePath, filePath);
-  console.log(`[input] using local video, duration=${Math.round(durationSec)}s`);
+  console.log(
+    `[input] using local video, duration=${Math.round(durationSec)}s`,
+  );
   return { filePath, videoId, workDir, durationSec };
 }
 
@@ -544,6 +578,8 @@ async function main(): Promise<void> {
     videoPath: filePath,
     framesDir,
     fps: config.fps,
+    sampleWidth: config.sampleWidth,
+    jpegQuality: config.jpegQuality,
     start: config.start,
     end: config.end,
     durationSec,
@@ -560,6 +596,7 @@ async function main(): Promise<void> {
     requireEndScreen: config.requireEndScreen,
     dedupGap: config.dedupGap,
     skipAheadFrames: config.skipAheadFrames,
+    concurrency: config.ocrConcurrency,
   });
   console.log(
     `[ocr] ${confirmed.length} confirmed scoreboard frames` +

--- a/scripts/scoreboard-harvester/ocr-tool/vision-ocr.swift
+++ b/scripts/scoreboard-harvester/ocr-tool/vision-ocr.swift
@@ -3,6 +3,9 @@
 //
 // Minimal CLI that runs Apple's Vision framework text recognition on a single
 // image file and prints recognized text lines as a JSON string array on stdout.
+// Daemon mode keeps one process alive, reading image paths from stdin and
+// writing one JSON object per line: {"ok":true,"text":[...]} or
+// {"ok":false,"error":"..."}.
 // Game-agnostic: the keyword matching lives in TypeScript.
 // Exits 0 on success, non-zero on failure (with diagnostic on stderr).
 //
@@ -11,6 +14,7 @@
 //
 // Usage:
 //   vision-ocr <image-path>
+//   vision-ocr --daemon
 //
 // Output format (stdout):
 //   ["WINNER","BLUE","3","GOALS","SHOTS",...]
@@ -20,61 +24,133 @@ import AppKit
 import Foundation
 import Vision
 
+/**
+ * Writes a diagnostic line to stderr.
+ *
+ * - Parameter message: The message to write.
+ */
+func writeStderr(_ message: String) {
+    FileHandle.standardError.write(Data("\(message)\n".utf8))
+}
+
+/**
+ * Writes a JSON value followed by a newline to stdout.
+ *
+ * - Parameter value: JSON-serializable payload.
+ */
+func writeJsonLine(_ value: Any) throws {
+    let payload = try JSONSerialization.data(withJSONObject: value, options: [])
+    FileHandle.standardOutput.write(payload)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+/**
+ * Runs Apple's Vision OCR on one image path.
+ *
+ * - Parameter imagePath: Absolute or relative image path.
+ * - Returns: Recognized text lines, sorted top-to-bottom.
+ */
+func recognizeText(imagePath: String) throws -> [String] {
+    guard
+        let nsImage = NSImage(contentsOfFile: imagePath),
+        let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil)
+    else {
+        throw NSError(
+            domain: "vision-ocr",
+            code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "failed to load image: \(imagePath)"]
+        )
+    }
+
+    let semaphore = DispatchSemaphore(value: 0)
+    var recognizedLines: [String] = []
+    var failure: Error? = nil
+
+    let request = VNRecognizeTextRequest { req, err in
+        defer { semaphore.signal() }
+        if let err = err {
+            failure = err
+            return
+        }
+        let observations = req.results as? [VNRecognizedTextObservation] ?? []
+        // Sort top-to-bottom for stable output. Vision returns observations roughly
+        // in reading order, but we explicitly sort by y descending (origin is
+        // bottom-left in Vision's normalized coordinates).
+        let sorted = observations.sorted { a, b in
+            a.boundingBox.origin.y > b.boundingBox.origin.y
+        }
+        recognizedLines = sorted.compactMap { $0.topCandidates(1).first?.string }
+    }
+
+    // Accurate is ~2x slower than .fast but dramatically better on stylized UI
+    // text like the RL scoreboard. usesLanguageCorrection off because scoreboards
+    // are short tokens / numbers, not natural language.
+    request.recognitionLevel = .accurate
+    request.usesLanguageCorrection = false
+    request.recognitionLanguages = ["en-US"]
+
+    do {
+        try VNImageRequestHandler(cgImage: cgImage, options: [:]).perform([request])
+    } catch {
+        failure = error
+        semaphore.signal()
+    }
+
+    semaphore.wait()
+
+    if let failure = failure {
+        throw failure
+    }
+
+    return recognizedLines
+}
+
+/**
+ * Handles the original single-image CLI mode.
+ *
+ * - Parameter imagePath: Image path to OCR.
+ */
+func runSingle(imagePath: String) {
+    do {
+        let lines = try recognizeText(imagePath: imagePath)
+        let payload = try JSONSerialization.data(withJSONObject: lines, options: [])
+        FileHandle.standardOutput.write(payload)
+    } catch {
+        writeStderr(error.localizedDescription)
+        exit(4)
+    }
+}
+
+/**
+ * Handles persistent worker mode. Each stdin line is an image path; each stdout
+ * line is a JSON result object. EOF exits cleanly.
+ */
+func runDaemon() {
+    while let imagePath = readLine(strippingNewline: true) {
+        if imagePath.isEmpty {
+            continue
+        }
+        do {
+            let lines = try recognizeText(imagePath: imagePath)
+            try writeJsonLine(["ok": true, "text": lines])
+        } catch {
+            do {
+                try writeJsonLine(["ok": false, "error": error.localizedDescription])
+            } catch {
+                writeStderr(error.localizedDescription)
+                exit(5)
+            }
+        }
+    }
+}
+
 guard CommandLine.arguments.count >= 2 else {
-    FileHandle.standardError.write(Data("usage: vision-ocr <image>\n".utf8))
+    writeStderr("usage: vision-ocr <image> | vision-ocr --daemon")
     exit(2)
 }
 
-let imagePath = CommandLine.arguments[1]
-
-guard
-    let nsImage = NSImage(contentsOfFile: imagePath),
-    let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil)
-else {
-    FileHandle.standardError.write(Data("failed to load image: \(imagePath)\n".utf8))
-    exit(3)
+if CommandLine.arguments[1] == "--daemon" {
+    runDaemon()
+} else {
+    runSingle(imagePath: CommandLine.arguments[1])
 }
-
-let semaphore = DispatchSemaphore(value: 0)
-var recognizedLines: [String] = []
-var failure: String? = nil
-
-let request = VNRecognizeTextRequest { req, err in
-    defer { semaphore.signal() }
-    if let err = err {
-        failure = err.localizedDescription
-        return
-    }
-    let observations = req.results as? [VNRecognizedTextObservation] ?? []
-    // Sort top-to-bottom for stable output. Vision returns observations roughly
-    // in reading order, but we explicitly sort by y descending (origin is
-    // bottom-left in Vision's normalized coordinates).
-    let sorted = observations.sorted { a, b in
-        a.boundingBox.origin.y > b.boundingBox.origin.y
-    }
-    recognizedLines = sorted.compactMap { $0.topCandidates(1).first?.string }
-}
-
-// Accurate is ~2x slower than .fast but dramatically better on stylized UI
-// text like the RL scoreboard. usesLanguageCorrection off because scoreboards
-// are short tokens / numbers, not natural language.
-request.recognitionLevel = .accurate
-request.usesLanguageCorrection = false
-request.recognitionLanguages = ["en-US"]
-
-do {
-    try VNImageRequestHandler(cgImage: cgImage, options: [:]).perform([request])
-} catch {
-    failure = error.localizedDescription
-    semaphore.signal()
-}
-
-semaphore.wait()
-
-if let failure = failure {
-    FileHandle.standardError.write(Data("\(failure)\n".utf8))
-    exit(4)
-}
-
-let payload = try JSONSerialization.data(withJSONObject: recognizedLines, options: [])
-FileHandle.standardOutput.write(payload)

--- a/scripts/scoreboard-harvester/pipeline/ocr.ts
+++ b/scripts/scoreboard-harvester/pipeline/ocr.ts
@@ -1,5 +1,6 @@
-import { runCapture } from "../utils";
-import { FrameRecord, OcrRecord } from "../types";
+import { spawn } from "child_process";
+import type { ChildProcessWithoutNullStreams } from "child_process";
+import type { FrameRecord, OcrRecord } from "../types";
 
 export interface OcrOptions {
   /** Absolute path to the compiled vision-ocr Swift binary. */
@@ -31,15 +32,33 @@ export interface OcrOptions {
    * a sparse pHash-survivor subset.
    */
   skipAheadFrames: number;
+  /**
+   * Number of persistent OCR workers to keep alive. Results are still applied
+   * in frame order so skip-ahead behavior matches the sequential state machine.
+   */
+  concurrency: number;
+}
+
+interface OcrAttempt {
+  frame: FrameRecord;
+  lines?: string[];
+  error?: unknown;
+}
+
+interface OcrDaemonResponse {
+  ok?: unknown;
+  text?: unknown;
+  error?: unknown;
 }
 
 /**
- * Runs OCR over the given frames in sequence, returning the ones that meet
- * the keyword threshold (and the end-screen sentinel rule, if enabled).
+ * Runs OCR over the given frames, returning the ones that meet the keyword
+ * threshold (and the end-screen sentinel rule, if enabled).
  *
- * Sequential because vision-ocr is single-threaded per invocation and macOS
- * Vision already uses all cores internally on .accurate mode; parallel
- * spawns deliver minimal speedup and complicate progress logging.
+ * OCR is executed through one or more persistent vision-ocr daemon workers so
+ * the Swift/Vision process startup cost is paid once per worker, not once per
+ * frame. Results are applied in ascending frame order to preserve the original
+ * skip-ahead state machine.
  *
  * SKIP-AHEAD: once a run of confirmed frames ends — defined as seeing an
  * unconfirmed frame whose frameId is more than `dedupGap` past the last
@@ -59,99 +78,371 @@ export async function ocrFrames(
 ): Promise<OcrRecord[]> {
   const out: OcrRecord[] = [];
   const sentinel = opts.endScreenSentinel?.toUpperCase();
+  const keywords = opts.keywords.map((keyword) => ({
+    raw: keyword,
+    upper: keyword.toUpperCase(),
+  }));
+  const concurrency = Number.isFinite(opts.concurrency)
+    ? Math.max(1, Math.floor(opts.concurrency))
+    : 1;
 
   // State for skip-ahead.
   let lastConfirmedFrameId = -1;
   let inRun = false;
   let skipToFrameId = -1;
   let skippedTotal = 0;
+  let ignoredInFlight = 0;
 
-  for (let i = 0; i < frames.length; i++) {
-    const f = frames[i];
+  if (frames.length === 0) return out;
 
-    if (opts.skipAheadFrames > 0 && f.frameId < skipToFrameId) {
-      skippedTotal++;
-      continue;
-    }
+  console.log(`[ocr] starting ${concurrency} persistent worker(s)`);
+  const workerPool = new OcrWorkerPool(opts.visionOcrPath, concurrency);
+  const inflight = new Map<number, Promise<OcrAttempt>>();
+  const skippedIndices = new Set<number>();
+  let nextToSchedule = 0;
+  let nextToProcess = 0;
 
-    let lines: string[];
-    try {
-      lines = await runOcr(opts.visionOcrPath, f.filePath);
-    } catch (err) {
-      console.warn(
-        `[ocr] frame ${f.frameId} failed: ${err instanceof Error ? err.message : err}`,
-      );
-      continue;
-    }
+  /**
+   * Keeps the worker pool full while honoring any skip-ahead boundary that is
+   * already known at schedule time.
+   */
+  function scheduleUntilFull(): void {
+    while (inflight.size < concurrency && nextToSchedule < frames.length) {
+      const index = nextToSchedule;
+      const frame = frames[index];
+      nextToSchedule++;
 
-    const upperLines = lines.map((l) => l.toUpperCase());
-    const matched = opts.keywords.filter((k) =>
-      upperLines.some((line) => line.includes(k.toUpperCase())),
-    );
-
-    const passesKeywordCount = matched.length >= opts.minKeywords;
-    // Sentinel can be detected either via the keyword-match list OR by
-    // scanning OCR lines directly. The latter handles game profiles that
-    // declare an endScreenSentinel that is NOT also in `keywords` — without
-    // the line-scan, those profiles would always fail when requireEndScreen
-    // is on, even with a perfect OCR result.
-    const passesSentinelRule =
-      !opts.requireEndScreen ||
-      sentinel === undefined ||
-      matched.some((k) => k.toUpperCase() === sentinel) ||
-      upperLines.some((line) => line.includes(sentinel));
-
-    if (passesKeywordCount && passesSentinelRule) {
-      out.push({
-        ...f,
-        text: lines,
-        matchedKeywords: [...matched],
-      });
-      lastConfirmedFrameId = f.frameId;
-      inRun = true;
-    } else if (
-      inRun &&
-      f.frameId - lastConfirmedFrameId > opts.dedupGap
-    ) {
-      // We just confirmed we've exited a run. Schedule a skip-ahead.
-      if (opts.skipAheadFrames > 0) {
-        skipToFrameId = lastConfirmedFrameId + opts.skipAheadFrames;
-        console.log(
-          `[ocr] skip-ahead: run ended at frame ${lastConfirmedFrameId}, ` +
-            `jumping past frame ${skipToFrameId - 1}`,
-        );
+      if (opts.skipAheadFrames > 0 && frame.frameId < skipToFrameId) {
+        skippedTotal++;
+        skippedIndices.add(index);
+        continue;
       }
-      inRun = false;
-    }
 
-    if ((i + 1) % 50 === 0 || i === frames.length - 1) {
-      console.log(
-        `[ocr] ${i + 1}/${frames.length} confirmed=${out.length}` +
-          (skippedTotal > 0 ? ` skipped=${skippedTotal}` : ""),
+      inflight.set(
+        index,
+        workerPool
+          .recognize(frame.filePath)
+          .then((lines) => ({ frame, lines }))
+          .catch((error) => ({ frame, error })),
       );
     }
   }
 
-  if (skippedTotal > 0) {
+  /**
+   * Logs progress at the same cadence as the old sequential loop.
+   *
+   * @param index - Zero-based frame index that was just resolved.
+   */
+  function logProgress(index: number): void {
+    if ((index + 1) % 50 === 0 || index === frames.length - 1) {
+      console.log(
+        `[ocr] ${index + 1}/${frames.length} confirmed=${out.length}` +
+          (skippedTotal > 0 ? ` skipped=${skippedTotal}` : "") +
+          (ignoredInFlight > 0 ? ` ignored=${ignoredInFlight}` : ""),
+      );
+    }
+  }
+
+  try {
+    while (nextToProcess < frames.length) {
+      scheduleUntilFull();
+
+      if (skippedIndices.delete(nextToProcess)) {
+        logProgress(nextToProcess);
+        nextToProcess++;
+        continue;
+      }
+
+      const pending = inflight.get(nextToProcess);
+      if (!pending) {
+        // This should only be reachable for an empty tail after schedule-time
+        // skips. Advance defensively rather than spinning forever.
+        logProgress(nextToProcess);
+        nextToProcess++;
+        continue;
+      }
+
+      const attempt = await pending;
+      inflight.delete(nextToProcess);
+
+      if (opts.skipAheadFrames > 0 && attempt.frame.frameId < skipToFrameId) {
+        ignoredInFlight++;
+        logProgress(nextToProcess);
+        nextToProcess++;
+        continue;
+      }
+
+      if (attempt.error) {
+        console.warn(
+          `[ocr] frame ${attempt.frame.frameId} failed: ${
+            attempt.error instanceof Error
+              ? attempt.error.message
+              : attempt.error
+          }`,
+        );
+        logProgress(nextToProcess);
+        nextToProcess++;
+        continue;
+      }
+
+      const lines = attempt.lines ?? [];
+      const upperLines = lines.map((line) => line.toUpperCase());
+      const matched = keywords
+        .filter((keyword) =>
+          upperLines.some((line) => line.includes(keyword.upper)),
+        )
+        .map((keyword) => keyword.raw);
+
+      const passesKeywordCount = matched.length >= opts.minKeywords;
+      // Sentinel can be detected either via the keyword-match list OR by
+      // scanning OCR lines directly. The latter handles game profiles that
+      // declare an endScreenSentinel that is NOT also in `keywords` — without
+      // the line-scan, those profiles would always fail when requireEndScreen
+      // is on, even with a perfect OCR result.
+      const passesSentinelRule =
+        !opts.requireEndScreen ||
+        sentinel === undefined ||
+        matched.some((k) => k.toUpperCase() === sentinel) ||
+        upperLines.some((line) => line.includes(sentinel));
+
+      if (passesKeywordCount && passesSentinelRule) {
+        out.push({
+          ...attempt.frame,
+          text: lines,
+          matchedKeywords: [...matched],
+        });
+        lastConfirmedFrameId = attempt.frame.frameId;
+        inRun = true;
+      } else if (
+        inRun &&
+        attempt.frame.frameId - lastConfirmedFrameId > opts.dedupGap
+      ) {
+        // We just confirmed we've exited a run. Schedule a skip-ahead.
+        if (opts.skipAheadFrames > 0) {
+          skipToFrameId = lastConfirmedFrameId + opts.skipAheadFrames;
+          console.log(
+            `[ocr] skip-ahead: run ended at frame ${lastConfirmedFrameId}, ` +
+              `jumping past frame ${skipToFrameId - 1}`,
+          );
+        }
+        inRun = false;
+      }
+
+      logProgress(nextToProcess);
+      nextToProcess++;
+    }
+  } finally {
+    await workerPool.close();
+  }
+
+  if (skippedTotal > 0)
     console.log(
       `[ocr] skip-ahead saved ${skippedTotal} OCR calls ` +
         `(~${Math.round((skippedTotal / frames.length) * 100)}% of frames)`,
     );
-  }
+  if (ignoredInFlight > 0)
+    console.log(
+      `[ocr] ignored ${ignoredInFlight} already-in-flight OCR result(s) after skip-ahead`,
+    );
 
   return out;
 }
 
 /**
- * Spawns vision-ocr for a single image and parses its JSON output.
+ * Manages a pool of persistent vision-ocr daemon processes.
+ */
+class OcrWorkerPool {
+  private readonly workers: OcrDaemonWorker[];
+  private nextWorker = 0;
+
+  /**
+   * Creates a pool of daemon workers.
+   *
+   * @param binPath - Resolved path to the vision-ocr binary.
+   * @param concurrency - Number of workers to spawn.
+   */
+  constructor(binPath: string, concurrency: number) {
+    this.workers = Array.from(
+      { length: concurrency },
+      (_, index) => new OcrDaemonWorker(binPath, index + 1),
+    );
+  }
+
+  /**
+   * Sends one image to the next daemon in round-robin order.
+   *
+   * @param imagePath - Image path to OCR.
+   * @returns Recognized text lines.
+   */
+  recognize(imagePath: string): Promise<string[]> {
+    const worker = this.workers[this.nextWorker];
+    this.nextWorker = (this.nextWorker + 1) % this.workers.length;
+    return worker.recognize(imagePath);
+  }
+
+  /**
+   * Gracefully shuts down every daemon.
+   */
+  async close(): Promise<void> {
+    await Promise.all(this.workers.map((worker) => worker.close()));
+  }
+}
+
+/**
+ * Wraps one long-lived vision-ocr --daemon process.
  *
  * @param binPath - Resolved path to the vision-ocr binary.
- * @param imagePath - Image file to OCR.
- * @returns Array of recognized text lines.
  */
-async function runOcr(binPath: string, imagePath: string): Promise<string[]> {
-  const stdout = await runCapture(binPath, [imagePath]);
-  const parsed: unknown = JSON.parse(stdout);
-  if (!Array.isArray(parsed)) return [];
-  return parsed.filter((x): x is string => typeof x === "string");
+class OcrDaemonWorker {
+  private readonly proc: ChildProcessWithoutNullStreams;
+  private readonly pending: Array<{
+    imagePath: string;
+    resolve: (lines: string[]) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private stdoutBuffer = "";
+  private stderr = "";
+  private closing = false;
+
+  /**
+   * Starts one daemon process.
+   *
+   * @param binPath - Resolved path to the vision-ocr binary.
+   * @param id - Worker ID used in diagnostics.
+   */
+  constructor(
+    binPath: string,
+    private readonly id: number,
+  ) {
+    this.proc = spawn(binPath, ["--daemon"]);
+    this.proc.stdout.on("data", (data) => this.handleStdout(data));
+    this.proc.stderr.on("data", (data) => {
+      this.stderr = (this.stderr + String(data)).slice(-4000);
+    });
+    this.proc.on("error", (err) => this.rejectPending(err));
+    this.proc.on("close", (code) => {
+      if (this.pending.length === 0) return;
+      const suffix = this.stderr.trim() ? `: ${this.stderr.trim()}` : "";
+      this.rejectPending(
+        new Error(
+          `vision-ocr worker ${this.id} exited with code ${code}${suffix}`,
+        ),
+      );
+    });
+  }
+
+  /**
+   * Sends one image path to the daemon.
+   *
+   * @param imagePath - Image path to OCR.
+   * @returns Recognized text lines.
+   */
+  recognize(imagePath: string): Promise<string[]> {
+    if (this.proc.exitCode !== null)
+      return Promise.reject(
+        new Error(`vision-ocr worker ${this.id} is not running`),
+      );
+
+    return new Promise((resolve, reject) => {
+      const request = {
+        imagePath,
+        resolve,
+        reject,
+      };
+      this.pending.push(request);
+      this.proc.stdin.write(`${imagePath}\n`, (err) => {
+        if (!err) return;
+        const index = this.pending.indexOf(request);
+        if (index >= 0) this.pending.splice(index, 1);
+        reject(err);
+      });
+    });
+  }
+
+  /**
+   * Gracefully exits the daemon after all queued requests complete.
+   */
+  close(): Promise<void> {
+    this.closing = true;
+    if (this.proc.exitCode !== null) return Promise.resolve();
+
+    return new Promise((resolve) => {
+      this.proc.once("close", () => resolve());
+      this.proc.stdin.end();
+    });
+  }
+
+  /**
+   * Parses newline-delimited daemon responses.
+   *
+   * @param data - stdout chunk from the daemon.
+   */
+  private handleStdout(data: Buffer): void {
+    this.stdoutBuffer += String(data);
+    let newline = this.stdoutBuffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = this.stdoutBuffer.slice(0, newline);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      this.handleLine(line);
+      newline = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  /**
+   * Resolves or rejects the oldest pending OCR request.
+   *
+   * @param line - One JSON response line from the daemon.
+   */
+  private handleLine(line: string): void {
+    if (line.trim() === "") return;
+    const request = this.pending.shift();
+    if (!request) {
+      console.warn(
+        `[ocr] worker ${this.id} emitted an unexpected line: ${line}`,
+      );
+      return;
+    }
+
+    let parsed: OcrDaemonResponse;
+    try {
+      parsed = JSON.parse(line) as OcrDaemonResponse;
+    } catch (err) {
+      request.reject(
+        new Error(
+          `vision-ocr worker ${this.id} emitted invalid JSON for ${request.imagePath}: ${
+            err instanceof Error ? err.message : err
+          }`,
+        ),
+      );
+      return;
+    }
+
+    if (parsed.ok === true) {
+      const lines = Array.isArray(parsed.text)
+        ? parsed.text.filter((x): x is string => typeof x === "string")
+        : [];
+      request.resolve(lines);
+      return;
+    }
+
+    request.reject(
+      new Error(
+        typeof parsed.error === "string"
+          ? parsed.error
+          : `vision-ocr worker ${this.id} failed on ${request.imagePath}`,
+      ),
+    );
+  }
+
+  /**
+   * Rejects all queued requests after a process-level failure.
+   *
+   * @param err - Failure to propagate.
+   */
+  private rejectPending(err: Error): void {
+    if (this.closing && this.pending.length === 0) return;
+    while (this.pending.length > 0) {
+      this.pending.shift()?.reject(err);
+    }
+  }
 }

--- a/scripts/scoreboard-harvester/pipeline/sample.ts
+++ b/scripts/scoreboard-harvester/pipeline/sample.ts
@@ -6,7 +6,7 @@ import { FrameRecord } from "../types";
 /**
  * Extracts frames from a video at the given fps into `framesDir` as JPEGs.
  * Uses VideoToolbox hardware acceleration on Apple Silicon for ~3x speedup.
- * Frames are normalized to 1280px wide so downstream pHash + OCR see a
+ * Frames are normalized to a fixed width so downstream pHash + OCR see a
  * consistent scale. If the directory already has frames, extraction is
  * skipped (resumability) — but the frame count is sanity-checked against
  * the expected duration to detect a previously-interrupted extraction.
@@ -15,6 +15,8 @@ import { FrameRecord } from "../types";
  * @param args.videoPath - Absolute path to the input video.
  * @param args.framesDir - Where to write the JPEG sequence.
  * @param args.fps - Sampling rate (frames per second). 1 is plenty for end-game scoreboards.
+ * @param args.sampleWidth - Output JPEG width in pixels.
+ * @param args.jpegQuality - ffmpeg JPEG quality. Lower is higher quality.
  * @param args.start - Optional start time in seconds (for testing on a slice).
  * @param args.end - Optional end time in seconds.
  * @param args.durationSec - Optional source duration; used to sanity-check
@@ -26,12 +28,23 @@ export async function sampleFrames(args: {
   videoPath: string;
   framesDir: string;
   fps: number;
+  sampleWidth: number;
+  jpegQuality: number;
   start?: number;
   end?: number;
   durationSec?: number;
 }): Promise<FrameRecord[]> {
-  const { ffmpegPath, videoPath, framesDir, fps, start, end, durationSec } =
-    args;
+  const {
+    ffmpegPath,
+    videoPath,
+    framesDir,
+    fps,
+    sampleWidth,
+    jpegQuality,
+    start,
+    end,
+    durationSec,
+  } = args;
   fs.mkdirSync(framesDir, { recursive: true });
 
   const existing = fs
@@ -40,7 +53,9 @@ export async function sampleFrames(args: {
     .sort();
 
   if (existing.length === 0) {
-    console.log(`[sample] extracting frames at ${fps} fps`);
+    console.log(
+      `[sample] extracting frames at ${fps} fps, width=${sampleWidth}, q=${jpegQuality}`,
+    );
     const ffArgs: string[] = [
       "-hide_banner",
       "-loglevel",
@@ -51,6 +66,7 @@ export async function sampleFrames(args: {
     ];
     if (start !== undefined) ffArgs.push("-ss", String(start));
     ffArgs.push("-i", videoPath);
+    ffArgs.push("-map", "0:v:0", "-an", "-sn", "-dn");
     if (end !== undefined) {
       const duration = end - (start ?? 0);
       // ffmpeg silently produces zero output for `-t 0` or negative durations;
@@ -63,8 +79,8 @@ export async function sampleFrames(args: {
       }
       ffArgs.push("-t", String(duration));
     }
-    ffArgs.push("-vf", `fps=${fps},scale=1280:-2`);
-    ffArgs.push("-q:v", "3");
+    ffArgs.push("-vf", `fps=${fps},scale=${sampleWidth}:-2`);
+    ffArgs.push("-q:v", String(jpegQuality));
     ffArgs.push(path.join(framesDir, "%06d.jpg"));
     await runSpawn(ffmpegPath, ffArgs);
   } else {

--- a/scripts/scoreboard-harvester/types.ts
+++ b/scripts/scoreboard-harvester/types.ts
@@ -25,6 +25,12 @@ export interface ResolvedConfig {
    */
   skipAheadFrames: number;
   quality: number;
+  /** Width used when normalizing sampled frame JPEGs for pHash/OCR. */
+  sampleWidth: number;
+  /** ffmpeg JPEG quality for sampled frames. Lower is higher quality. */
+  jpegQuality: number;
+  /** Number of persistent OCR workers to run concurrently. */
+  ocrConcurrency: number;
   keepFrames: boolean;
   start?: number;
   end?: number;


### PR DESCRIPTION
Add vision-ocr --daemon mode with an ordered worker pool, plus CLI knobs for sample width, JPEG quality, and OCR concurrency to tune extraction and throughput.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new CLI parameters (`--sample-width`, `--jpeg-quality`, `--ocr-concurrency`) for fine-tuning frame sampling and OCR processing performance.
  * Upgraded OCR tool to support persistent background mode for enhanced concurrent request handling.

* **Documentation**
  * Expanded documentation with detailed parameter descriptions, performance-tuning guides, and comprehensive troubleshooting reference table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crashoutcompany/Project-RDC/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->